### PR TITLE
adding option to istanbul preprocessor to ignore the generated ts hel…

### DIFF
--- a/src/preprocessors/IstanbulPreprocessor.ts
+++ b/src/preprocessors/IstanbulPreprocessor.ts
@@ -8,11 +8,13 @@ export class IstanbulPreprocessor {
 	private specFiles: string[];
 	private srcFiles: string[];
 	private verbose: boolean;
+	private ignoreTsHelpers: boolean;
 	
-	constructor({specFiles = ["**/*.spec.js"], srcFiles = ["**/!(*.spec).js"], istanbulPreprocessor = {verbose: false}}){
+	constructor({specFiles = ["**/*.spec.js"], srcFiles = ["**/!(*.spec).js"], istanbulPreprocessor = {verbose: false, ignoreTsHelpers: true}}){
 		this.specFiles = specFiles;
 		this.srcFiles = srcFiles;
 		this.verbose = istanbulPreprocessor.verbose;
+		this.ignoreTsHelpers = istanbulPreprocessor.ignoreTsHelpers;
 	}
 	
 	public preprocess(): Promise<any>{		
@@ -20,6 +22,7 @@ export class IstanbulPreprocessor {
 		var instrumenter = new Istanbul.Instrumenter({ /*coverageVariable: coverageVar , preserveComments: preserveComments*/});
         var transformer = instrumenter.instrumentSync.bind(instrumenter);
 		var matcherFor:Function = Bluebird.promisify(Istanbul.matcherFor);
+		let tsHelperRegex = /var __(param|awaiter|metadata|decorate|extends)/;
 			
 		return matcherFor({
 			excludes: ["**/node_modules/**"].concat(this.specFiles),
@@ -28,8 +31,20 @@ export class IstanbulPreprocessor {
 			if(!global["__coverage__"]){			
 				global["__coverage__"] = [];
 			}			
-			matchFn.files.forEach(function (file) {    				         	
-				transformer(fs.readFileSync(file, 'utf-8'), file);
+			matchFn.files.forEach((file) => {
+				let fileContents = fs.readFileSync(file, "utf-8");
+				if(fileContents && this.ignoreTsHelpers){
+					let linesOfCode = fileContents.split("\n");					
+					for(let i = 0; i < linesOfCode.length; i++){	
+						if(tsHelperRegex.test(linesOfCode[i])){
+							console.log("adding istanbul ignore");
+							linesOfCode.splice(i, 0, "/* istanbul ignore next */");
+							i++;
+						}						
+					}  
+					fileContents = new Buffer(linesOfCode.join('\n')).toString();  			
+				}	         									
+				transformer(fileContents, file);
 				// When instrumenting the code, istanbul will give each FunctionDeclaration a value of 1 in coverState.s,
 				// presumably to compensate for function hoisting. We need to reset this, as the function was not hoisted,
 				// as it was never loaded.
@@ -41,6 +56,6 @@ export class IstanbulPreprocessor {
 				global["__coverage__"][file] = instrumenter.coverState;				
 			 });
 			hook.hookRequire(matchFn, transformer, {verbose: this.verbose});
-		});								
-	}		
+		});										
+	}			
 }


### PR DESCRIPTION
…per functions like __extends when calculating code coverage percentage.  Handles the helper functions for param, awaiter, decorate, extends, and metadat.  The actual output file is not altered but rather the file contents sent to transform
